### PR TITLE
Consume deps directly in repository.

### DIFF
--- a/src/app/api/items.py
+++ b/src/app/api/items.py
@@ -6,7 +6,6 @@ from starlite import Controller, Provide, Router, delete, get, post, put
 from app.config import Paths
 from app.models import ItemCreateModel, ItemModel, UserModel
 from app.repositories import ItemRepository, UserRepository
-from app.utils import BeforeAfter, LimitOffset
 
 from .utils import CheckPayloadMismatch, filter_for_updated, limit_offset_pagination
 
@@ -50,11 +49,7 @@ class ItemsController(Controller):
         self,
         user: UserModel,
         repository: ItemRepository,
-        limit_offset: LimitOffset,
-        updated_filter: BeforeAfter,
     ) -> list[ItemModel]:
-        repository.apply_limit_offset_pagination(limit_offset)
-        repository.filter_on_datetime_field(updated_filter)
         return await repository.get_many_for_user(user=user)
 
 

--- a/src/app/api/users.py
+++ b/src/app/api/users.py
@@ -6,7 +6,6 @@ from starlite import Controller, Parameter, Provide, Router, delete, get, post, 
 from app.config import Paths
 from app.models import UserCreateModel, UserModel
 from app.repositories import UserRepository
-from app.utils import BeforeAfter, LimitOffset
 
 from .utils import CheckPayloadMismatch, filter_for_updated, limit_offset_pagination
 
@@ -40,12 +39,8 @@ class UsersController(Controller):
     async def get(
         self,
         repository: UserRepository,
-        limit_offset: LimitOffset,
-        updated_filter: BeforeAfter,
         is_active: bool = Parameter(query="is-active", default=True),
     ) -> list[UserModel]:
-        repository.apply_limit_offset_pagination(limit_offset)
-        repository.filter_on_datetime_field(updated_filter)
         return await repository.get_many(is_active=is_active)
 
 

--- a/src/app/api/utils.py
+++ b/src/app/api/utils.py
@@ -46,7 +46,7 @@ def limit_offset_pagination(
     page_size : int
         OFFSET to apply to select.
     """
-    return LimitOffset(page_size, page - 1)
+    return LimitOffset(page_size, page_size * (page - 1))
 
 
 class CheckPayloadMismatch:

--- a/tests/users/test_controller.py
+++ b/tests/users/test_controller.py
@@ -73,9 +73,15 @@ def test_get_users_filter_by_updated(
     "params, call_arg",
     [
         ({}, LimitOffset(app_settings.DEFAULT_PAGINATION_LIMIT, 0)),
-        ({"page": 11}, LimitOffset(app_settings.DEFAULT_PAGINATION_LIMIT, 10)),
+        (
+            {"page": 11},
+            LimitOffset(
+                app_settings.DEFAULT_PAGINATION_LIMIT,
+                app_settings.DEFAULT_PAGINATION_LIMIT * 10,
+            ),
+        ),
         ({"page-size": 11}, LimitOffset(11, 0)),
-        ({"page": 11, "page-size": 11}, LimitOffset(11, 10)),
+        ({"page": 11, "page-size": 11}, LimitOffset(11, 110)),
     ],
 )
 @pytest.mark.parametrize("patch_repo_scalars", ["db_users"], indirect=True)


### PR DESCRIPTION
Pagination and Updated datetime filter are now optionally consumed by the repository dependency if they are available. Simply define the `limit_offset` and/or `updated_filter` dependencies for the route.

Includes a fix for incorrect pagination logic, where the offset wasn't a multiple of the page size.