### PR TITLE
Config to unify all logging through the "queue_listener" handler.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 # App
 DEBUG=true
 DEFAULT_PAGINATION_LIMIT=100
+LOG_LEVEL=INFO
 
 # Cache
 REDIS_URL=redis://cache:6379/0

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -1,10 +1,12 @@
 from app.config import gunicorn_settings
+from app.logging import log_config
 
 # Gunicorn config variables
 accesslog = gunicorn_settings.ACCESS_LOG
 bind = f"{gunicorn_settings.HOST}:{gunicorn_settings.PORT}"
 errorlog = gunicorn_settings.ERROR_LOG
 keepalive = gunicorn_settings.KEEPALIVE
+logconfig_dict = log_config.dict(exclude_none=True)
 loglevel = gunicorn_settings.LOG_LEVEL
 reload = gunicorn_settings.RELOAD
 threads = gunicorn_settings.THREADS

--- a/src/app/config.py
+++ b/src/app/config.py
@@ -1,5 +1,4 @@
 from pydantic import AnyUrl, BaseSettings, PostgresDsn
-from starlite import LoggingConfig
 
 
 class AppSettings(BaseSettings):
@@ -8,6 +7,7 @@ class AppSettings(BaseSettings):
 
     DEBUG: bool
     DEFAULT_PAGINATION_LIMIT: int
+    LOG_LEVEL: str
 
 
 class CacheSettings(BaseSettings):
@@ -57,9 +57,3 @@ app_settings = AppSettings()
 cache_settings = CacheSettings()
 db_settings = DatabaseSettings()
 gunicorn_settings = GunicornSettings()
-
-log_config = LoggingConfig(
-    loggers={
-        "app": {"level": "INFO", "handlers": ["queue_listener"], "propagate": False}
-    }
-)

--- a/src/app/logging.py
+++ b/src/app/logging.py
@@ -1,0 +1,59 @@
+import logging
+import re
+from typing import Any
+
+from starlette.status import HTTP_200_OK
+from starlite import LoggingConfig
+
+from app.config import Paths, app_settings
+
+
+class UvicornAccessLogFilter(logging.Filter):
+    def __init__(self, *args: Any, path_re: str, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.path_filter = re.compile(path_re)
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        *_, req_path, _, status_code = record.args  # type:ignore[misc]
+        if (
+            self.path_filter.match(req_path)  # type:ignore[arg-type]
+            and status_code == HTTP_200_OK
+        ):
+            return False
+        return True
+
+
+log_config = LoggingConfig(
+    root={"level": app_settings.LOG_LEVEL, "handlers": ["queue_listener"]},
+    filters={
+        "health_filter": {
+            "()": UvicornAccessLogFilter,
+            "path_re": f"^{Paths.HEALTH}$",
+        }
+    },
+    formatters={
+        "standard": {"format": "%(levelname)s - %(asctime)s - %(name)s - %(message)s"}
+    },
+    loggers={
+        "app": {
+            "propagate": True,
+        },
+        "gunicorn.error": {
+            "propagate": True,
+        },
+        "uvicorn.access": {
+            "propagate": True,
+            "filters": ["health_filter"],
+        },
+        "uvicorn.error": {
+            "propagate": True,
+        },
+        "sqlalchemy.engine": {
+            "propagate": True,
+        },
+        "starlite": {
+            "level": "WARNING",
+            "propagate": True,
+        },
+    },
+)

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -3,7 +3,8 @@ from starlite import Starlite
 from starlite.plugins.sql_alchemy import SQLAlchemyPlugin
 
 from app import api, cache, db, exceptions, health, openapi
-from app.config import app_settings, log_config
+from app.config import app_settings
+from app.logging import log_config
 
 app = Starlite(
     after_request=db.session_after_request,


### PR DESCRIPTION
- adds an application config `LOG_LEVEL`.
- moves the `log_config` from `app.config` to new `app.logging` module.
- tells gunicorn to use the app defined `log_config`.
- includes an access log filter so we can filter health checks from access logs when they return 200.

Closes #41 