### PR TITLE
FIX: Added "in project" venvs to gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ __pycache__/
 .coverage
 .dmypy.json
 .DS_Store
+.venv
+venv


### PR DESCRIPTION
The 'create virtual environments in project' setting within poetry.  This settings makes `poetry install`  create a hidden folder in `.venv` for the poetry environment that should be ignored.