### PR TITLE
Fix `validate` step in pre-commit action

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -152,7 +152,7 @@ repos:
             uvicorn,
           ]
   - repo: https://github.com/RobertCraigie/pyright-python
-    rev: v1.1.275
+    rev: v1.1.280
     hooks:
       - id: pyright
         exclude: "alembic"

--- a/app/lib/worker.py
+++ b/app/lib/worker.py
@@ -1,6 +1,8 @@
 import asyncio
 from collections import abc
+from collections.abc import Collection  # noqa: TC003
 from functools import partial
+from signal import Signals  # noqa: TC003
 from typing import Any
 
 import orjson
@@ -19,7 +21,7 @@ __all__ = [
 WorkerFunction = abc.Callable[..., abc.Awaitable[Any]]
 
 
-class Queue(saq.Queue):  # type:ignore[misc]
+class Queue(saq.Queue):
     """[SAQ Queue](https://github.com/tobymao/saq/blob/master/saq/queue.py)
 
     Configures `orjson` for JSON serialization/deserialization if not otherwise configured.
@@ -38,9 +40,9 @@ class Queue(saq.Queue):  # type:ignore[misc]
         super().__init__(*args, **kwargs)
 
 
-class Worker(saq.Worker):  # type:ignore[misc]
+class Worker(saq.Worker):
     # same issue: https://github.com/samuelcolvin/arq/issues/182
-    SIGNALS: list[str] = []
+    SIGNALS: list[Signals] = []
 
     async def on_app_startup(self) -> None:
         """Attach the worker to the running event loop."""
@@ -55,7 +57,7 @@ instance.
 """
 
 
-def create_worker_instance(functions: abc.Iterable[WorkerFunction]) -> Worker:
+def create_worker_instance(functions: Collection[WorkerFunction]) -> Worker:
     """
 
     Args:


### PR DESCRIPTION
Hi there,

I noticed that the project uses some kind of cache for the actions and since I just forked this repository I did not have it. I noticed that the `validate` step was failing because of Mypy. 
Here's a link to the error that I was getting.

https://github.com/sorasful/starlite-pg-redis-docker/actions/runs/3499905155/jobs/5861992830  

This PR is to fix these problems, you can see my actions running here. (I did not setup Sonar, that's why it's broken).
https://github.com/sorasful/starlite-pg-redis-docker/actions/runs/3500361917

I also updated pyright version to get rid of a warning. 

Cheers !