### PR TITLE
only install main dependencies in prod image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ COPY pyproject.toml poetry.lock ./
 
 # install only production dependencies
 RUN --mount=type=cache,target=/cache/poetry \
-    poetry install --no-root --no-dev
+    poetry install --no-root --only main
 
 
 FROM base-prod AS base-dev


### PR DESCRIPTION
I forgot to fix this detail in #149 

Currently the project's `pyproject.toml` is not using the old `--dev` notation, it's using poetry's dependency groups.  `--only main` has to be passed to `poetry install` n order to only install the default dependencies for the production image.

# PR Checklist

- [ ] Have you followed the guidelines in `CONTRIBUTING.rst`?
- [ ] Have you got 100% test coverage on new code?
- [ ] Have you updated the prose documentation?
- [ ] Have you updated the reference documentation?
