### PR TITLE
Added Healthchecker to pg container and depends on it being healthy

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,7 +4,6 @@ services:
     image: redis:latest
     ports:
       - "6379:6379"
-    volumes:
       - cache:/data
 
   db:
@@ -16,6 +15,12 @@ services:
     environment:
       POSTGRES_PASSWORD: mysecretpassword
       POSTGRES_DB: example-pg-docker
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -d $${POSTGRES_DB} -U postgres"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 5s
 
   mailhog:
     image: mailhog/mailhog
@@ -29,9 +34,13 @@ services:
       args:
         INSTALL_DEPENDENCIES: dev
     depends_on:
-      - db
-      - mailhog
-      - redis
+      mailhog:
+        condition: service_started
+      redis:
+        condition: service_started
+      db:
+        condition: service_healthy
+
     ports:
       - "8000:8000"
     env_file:


### PR DESCRIPTION
- so that migrations won't fail on initial docker-compose initial launch

### Pull Request Checklist

[//]: # "Please review the [Starlite contribution guidelines](https://github.com/starlite-api/starlite/blob/main/CONTRIBUTING.rst) for this repository."

- [x] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

By submitting this issue, you agree to: 
- follow Starlite's [Code of Conduct](https://github.com/starlite-api/.github/blob/main/CODE_OF_CONDUCT.md)
- follow Starlite's [Contribution Guidelines](https://starliteproject.dev/community/contribution-guide)

### Description
Currently initial `docker-compose up --build` would fail to start starlite because db is not ready. So I added a
 Healthchecker to pg container and depends on it being healthy
- so that migrations won't fail on initial docker-compose launch
